### PR TITLE
Support separate "id" values on features.

### DIFF
--- a/src/NetTopologySuite.Features/FeatureExtensions.cs
+++ b/src/NetTopologySuite.Features/FeatureExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace NetTopologySuite.Features
+{
+    /// <summary>
+    /// Defines extensions for <see cref="IFeature"/>.
+    /// </summary>
+    public static class FeatureExtensions
+    {
+        /// <summary>
+        /// Gets an ID value from this <see cref="IFeature"/>, using its <see cref="IUnique.Id"/>
+        /// property if it happens to implement that interface (otherwise, searching through its
+        /// <see cref="IFeature.Attributes"/> looking for an attribute with a specified name).
+        /// </summary>
+        /// <param name="feature">
+        /// The <see cref="IFeature"/> whose ID to get.
+        /// </param>
+        /// <param name="idPropertyName">
+        /// The name of the attribute to look for in <see cref="IFeature.Attributes"/>, if the
+        /// <paramref name="feature"/> is not an instance of <see cref="IUnique"/>.
+        /// </param>
+        /// <returns>
+        /// The ID value, or <see langword="null"/> if this instance has no ID.
+        /// </returns>
+        public static object GetOptionalId(this IFeature feature, string idPropertyName)
+        {
+            return feature is IUnique unique
+                ? unique.Id
+                : feature?.Attributes?.GetOptionalValue(idPropertyName);
+        }
+    }
+}

--- a/src/NetTopologySuite.Features/IUnique.cs
+++ b/src/NetTopologySuite.Features/IUnique.cs
@@ -1,0 +1,13 @@
+﻿namespace NetTopologySuite.Features
+{
+    /// <summary>
+    /// Interface for things tagged by an identifier that's assumed to be unique.
+    /// </summary>
+    public interface IUnique
+    {
+        /// <summary>
+        /// Gets the identifier of this object (assumed unique).
+        /// </summary>
+        object Id { get; }
+    }
+}

--- a/test/NetTopologySuite.Features.Test/FeatureExtensionsTest.cs
+++ b/test/NetTopologySuite.Features.Test/FeatureExtensionsTest.cs
@@ -1,0 +1,52 @@
+﻿using NetTopologySuite.Geometries;
+
+using NUnit.Framework;
+
+namespace NetTopologySuite.Features.Test
+{
+    /// <summary>
+    /// A test fixture for the <see cref="FeatureExtensions"/> class
+    /// </summary>
+    public sealed class FeatureExtensionsTest
+    {
+        [Test]
+        public void GetOptionalIdTest_FromIUnique()
+        {
+            string idPropertyName = TestContext.CurrentContext.Random.GetString();
+            object idValue = TestContext.CurrentContext.Random.NextGuid();
+            object notIdValue = TestContext.CurrentContext.Random.NextGuid();
+            var feature = new UniqueFeature(idValue) { Attributes = new AttributesTable { { idPropertyName, notIdValue } } };
+
+            Assert.That(feature.GetOptionalId(idPropertyName), Is.EqualTo(idValue));
+        }
+
+        [Test]
+        public void GetOptionalIdTest_FromAttributes()
+        {
+            string idPropertyName = TestContext.CurrentContext.Random.GetString();
+            object idValue = TestContext.CurrentContext.Random.NextGuid();
+            var feature = new Feature { Attributes = new AttributesTable { { idPropertyName, idValue } } };
+
+            Assert.That(feature.GetOptionalId(idPropertyName), Is.EqualTo(idValue));
+        }
+
+        [Test]
+        public void GetOptionalIdTest_Missing()
+        {
+            Assert.That(default(IFeature).GetOptionalId("id"), Is.Null);
+            Assert.That(new Feature { Attributes = null }.GetOptionalId("id"), Is.Null);
+            Assert.That(new Feature { Attributes = new AttributesTable { { "notId", "ignored" } } }.GetOptionalId("id"), Is.Null);
+        }
+
+        private sealed class UniqueFeature : IFeature, IUnique
+        {
+            public UniqueFeature(object id)
+                => Id = id;
+
+            public object Id { get; }
+            public Geometry Geometry { get; set; }
+            public Envelope BoundingBox { get; set; }
+            public IAttributesTable Attributes { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
For context:
- https://github.com/NetTopologySuite/NetTopologySuite.IO.GeoJSON/issues/44#issuecomment-586599598
- https://github.com/NetTopologySuite/NetTopologySuite.IO.GeoJSON/issues/44#issuecomment-592401769

I don't think we need to go all the way to "`IUniqueFeature`", just "`IUnique`" should be enough.

Also, not all `IUnique` implementations will want the `Id` be settable, and we don't need it to be for any concrete plans that I know of right now, so just a getter for now.  It's possible to add a setter later without breaking anyone:
```csharp
public interface IEditableUnique : IUnique
{
    new object Id { set; }
}
```